### PR TITLE
FIX testando-aplicacoes-django NOSE_ARGS de str para tupla

### DIFF
--- a/testando-aplicacoes-django/index.html
+++ b/testando-aplicacoes-django/index.html
@@ -255,7 +255,7 @@ INSTALLED_APPS = (
 )
 </pre>
 <pre>TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'</pre>
-<pre class="build">NOSE_ARGS = '--with-coverage'</pre>
+<pre class="build">NOSE_ARGS = ('--with-coverage',)</pre>
                 </section>
             </div>
         </div>


### PR DESCRIPTION
`NOSE_ARGS` deve ser uma lista ou tupla.

Referencia:
https://github.com/jbalogh/django-nose/blob/master/django_nose/runner.py#L139
### Erro:

https://gist.github.com/cc4e5ff80fae3a691f81
